### PR TITLE
Formatting dates and splitting locations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,8 @@ fastapi
 pydantic>=2.0.0
 SPARQLWrapper
 translatepy
+https://github.com/semantic-ai/decide-ai-service-base/releases/download/0.1.2/decide_ai_service_base-0.1.2-py3-none-any.whl
+
 span-aligner>=0.2.4
-https://github.com/semantic-ai/decide-ai-service-base/releases/download/0.1.1/decide_ai_service_base-0.1.1-py3-none-any.whl
+locationformatter
+dateperiodparser

--- a/src/entity_mappers.py
+++ b/src/entity_mappers.py
@@ -123,9 +123,28 @@ def _annotate(task,subject: str, predicate: str, obj: str, source_uri: str, enti
     ).add_to_triplestore_if_not_exists()
 
 
+def _get_date_literal(entity: Dict[str, Any]) -> str:
+    """Get a SPARQL date literal from an entity, preferring formatted_text over raw text parsing."""
+    formatted_text = entity.get("formatted_text")
+    if formatted_text:
+        return formatted_text
+    return _parse_date_literal(entity.get("text", ""))
+
+def _get_period_literals(entity: Dict[str, Any]) -> tuple[str, str]:
+    """Extract start and end date literals from a period entity."""
+    formatted_start = entity.get("formatted_start")
+    formatted_end = entity.get("formatted_end")
+    if formatted_start and formatted_end:
+        return formatted_start, formatted_end
+    
+    # Fallback to parsing raw text if formatted values are not available.
+    falback = _parse_date_literal(entity.get("text", ""))
+    return falback, falback
+
+
 def _create_work_date_annotation(task, work_uri: Optional[str], source_uri: str, entity: Dict[str, Any], predicate_uri: str) -> List[str]:
     """Helper to create a single date statement on the work."""
-    obj_literal = _parse_date_literal(entity.get("text", ""))
+    obj_literal = _get_date_literal(entity)
     ann_uri = _annotate(
         task,
         subject=work_uri,
@@ -175,7 +194,7 @@ def _get_or_create_session_for_work(task, work_uri: Optional[str]) -> Optional[s
 
 def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str, entity: Dict[str, Any]) -> List[str]:
     """Map a refined entity into one or more RDF annotations.
-
+    for
     This is the main entry point used by EntityExtractionTask. It examines
     the entity's refined label and emits the appropriate Open Annotation +
     rdf:Statement structure in the AI/public graph.
@@ -194,6 +213,9 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
         It may be empty when the label is not handled or required context is
         missing (e.g. no work URI).
     """
+
+    print(f"[map_entity_to_annotations] Mapping entity: {entity} for expression {expression_uri} and work {work_uri}")
+
     label = str(entity.get("label", "")).upper()
 
     created: List[str] = []
@@ -249,8 +271,8 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
     if label == "CONTEXT_PERIOD":
         period_id = str(uuid.uuid4())
         period_uri = f"https://data.lblod.info/id/period/{period_id}"
-        begin_literal = _parse_date_literal(entity.get("text", ""))
-        end_literal = begin_literal  # minimal: same date for start/end
+        begin_literal, end_literal = _get_period_literals(entity)
+
         insert_body = f"""
     {sparql_escape_uri(period_uri)} a {sparql_escape_uri("http://www.w3.org/2006/time#ProperInterval")} ;
         {sparql_escape_uri("http://www.w3.org/2006/time#hasBeginning")} {begin_literal} ;
@@ -278,8 +300,8 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
         nb_id = str(uuid.uuid4())
         period_uri = f"https://data.lblod.info/id/period/{period_id}"
         nb_uri = f"https://data.lblod.info/id/normatievebepaling/{nb_id}"
-        begin_literal = _parse_date_literal(entity.get("text", ""))
-        end_literal = begin_literal
+        begin_literal, end_literal = _get_period_literals(entity)
+        
         insert_body = f"""
     {sparql_escape_uri(period_uri)} a {sparql_escape_uri("http://www.w3.org/2006/time#ProperInterval")} ;
         {sparql_escape_uri("http://www.w3.org/2006/time#hasBeginning")} {begin_literal} ;
@@ -325,7 +347,7 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
         if not session_uri:
             return created
 
-        date_literal = _parse_date_literal(entity.get("text", ""))
+        date_literal = _get_date_literal(entity)
         # Activity date
         ann1 = _annotate(
             task,
@@ -431,7 +453,7 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
     # Context location: general spatial context for the work.
     if label == "CONTEXT_LOCATION":
         loc_uri = f"http://www.example.org/id/.well-known/genid/{uuid.uuid4()}"
-        label_literal = sparql_escape_string(entity.get("text", ""))
+        label_literal = sparql_escape_string(entity.get("formatted_text") or entity.get("text", ""))
         insert_body = f"""
     {sparql_escape_uri(loc_uri)} a dct:Location ;
         rdfs:label {label_literal} .
@@ -452,7 +474,7 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
     # Impact location: where the decision has effect.
     if label == "IMPACT_LOCATION":
         loc_uri = f"http://www.example.org/id/.well-known/genid/{uuid.uuid4()}"
-        label_literal = sparql_escape_string(entity.get("text", ""))
+        label_literal = sparql_escape_string(entity.get("formatted_text") or entity.get("text", ""))
         insert_body = f"""
     {sparql_escape_uri(loc_uri)} a dct:Location ;
         rdfs:label {label_literal} .

--- a/src/entity_mappers.py
+++ b/src/entity_mappers.py
@@ -214,8 +214,6 @@ def map_entity_to_annotations(task, work_uri: Optional[str], expression_uri: str
         missing (e.g. no work URI).
     """
 
-    print(f"[map_entity_to_annotations] Mapping entity: {entity} for expression {expression_uri} and work {work_uri}")
-
     label = str(entity.get("label", "")).upper()
 
     created: List[str] = []

--- a/src/library/entity_formatter.py
+++ b/src/library/entity_formatter.py
@@ -1,0 +1,221 @@
+import uuid as _uuid_module
+from dateperiodparser import DatePeriodParser
+from locationformatter import LocationFormatter
+
+_PERIOD_BASE_URI = "https://data.lblod.info/id/period"
+
+
+class EntityFormatter:
+    """Routes extracted NER entities through formatting parsers based on label type.
+    """
+
+    DATE_LABELS = frozenset({
+        "DATE", "CONTEXT_DATE", "CONTEXT_PERIOD",
+        "ENTRY_DATE", "EXPIRY_DATE", "LEGAL_DATE",
+        "PUBLICATION_DATE", "SESSION_DATE", "VALIDITY_PERIOD",
+    })
+
+    LOCATION_LABELS = frozenset({
+        "LOCATION", "LOC", "GPE",
+        "CONTEXT_LOCATION", "IMPACT_LOCATION",
+    })
+
+    _DATE_OBJECT_MAP: dict[str, list[str]] = {
+        "DATE":             ["date"],
+        "CONTEXT_DATE":     ["date"],
+        "CONTEXT_PERIOD":   ["interval"],
+        "ENTRY_DATE":       ["date"],
+        "EXPIRY_DATE":      ["date"],
+        "LEGAL_DATE":       ["date"],
+        "PUBLICATION_DATE": ["date"],
+        "SESSION_DATE":     ["date"],
+        "VALIDITY_PERIOD":  ["interval"],
+    }
+
+    def __init__(self):
+        self._date_parser = DatePeriodParser()
+        self._location_formatter = LocationFormatter()
+
+    # ── public API ───────────────────────────────────────────────────
+
+    def format(self, entities: list[dict]) -> list[dict]:
+        """Format and expand — every entry holds exactly one RDF object / one address."""
+        output = []
+        for e in entities:
+            label = e.get("label", "")
+            if label in self.DATE_LABELS:
+                first, all_objects = self._format_date(e)
+                output.extend(self._expand(first, all_objects, self._date_entry))
+            elif label in self.LOCATION_LABELS:
+                first, all_locations = self._format_location(e)
+                output.extend(self._expand(first, all_locations, self._location_entry))
+            else:
+                output.append({**e, "formatted": None, "formatted_text": None, "result_object": None, "formatted_start": None, "formatted_end": None})
+        return output
+
+    # ── serialisation helpers ────────────────────────────────────────
+
+    @staticmethod
+    def _make_interval_obj(start_date: str, end_date: str) -> dict:
+        uid = str(_uuid_module.uuid4())
+        return {
+            "type":         "time:ProperInterval",
+            "uuid":         uid,
+            "uri":          f"{_PERIOD_BASE_URI}/{uid}",
+            "hasBeginning": start_date,
+            "hasEnd":       end_date,
+        }
+
+    @staticmethod
+    def _object_formatted_text(obj: dict) -> str:
+        if obj["type"] == "xsd:Date":
+            return f'"{obj["value"]}"^^xsd:Date'
+        return f'<{obj["uri"]}>'
+
+    @staticmethod
+    def _object_result_object(obj: dict) -> str | None:
+        if obj["type"] == "xsd:Date":
+            return None
+        uri = obj["uri"]
+        uid = obj["uuid"]
+        return (
+            f'<{uri}> a <http://www.w3.org/2006/time#ProperInterval> ;\n'
+            f'    mu:uuid "{uid}" ;\n'
+            f'    <http://www.w3.org/2006/time#hasBeginning> "{obj["hasBeginning"]}"^^xsd:Date ;\n'
+            f'    <http://www.w3.org/2006/time#hasEnd> "{obj["hasEnd"]}"^^xsd:Date .'
+        )
+
+    @staticmethod
+    def _date_parse_dict(dr) -> dict:
+        return {
+            "start":      dr.start.isoformat(),
+            "end":        dr.end.isoformat(),
+            "confidence": dr.confidence,
+            "pattern":    dr.pattern,
+        }
+
+    @staticmethod
+    def _address_text(loc: dict) -> str:
+        """Build a Nominatim-compatible address string using a priority chain.
+
+        Priority for the primary search term:
+          1. street  (+ housenumber + bus N)   — most geocoding-friendly
+          2. building                            — named building
+          3. road                                — highway / named road
+          4. intersection                        — road crossing
+          5. district                            — neighbourhood / district
+          6. domain_zone_area                    — zone or domain name
+          7. grave_location / parcel             — last resort (poor geocoding)
+          8. raw location span                   — absolute fallback
+
+        postcode, city and province are appended to whatever primary is chosen.
+        """
+        postcode_city = " ".join(filter(None, [loc.get("postcode") or "", loc.get("city") or ""]))
+        province      = loc.get("province") or ""
+
+        if loc.get("street"):
+            hn = loc.get("housenumber") or ""
+            if hn and loc.get("bus"):
+                hn = f"{hn} bus {loc['bus']}"
+            primary = " ".join(filter(None, [loc["street"], hn]))
+        elif loc.get("building"):
+            primary = loc["building"]
+        elif loc.get("road"):
+            primary = loc["road"]
+        elif loc.get("intersection"):
+            primary = loc["intersection"]
+        elif loc.get("district"):
+            primary = loc["district"]
+        elif loc.get("domain_zone_area"):
+            primary = loc["domain_zone_area"]
+        elif loc.get("grave_location"):
+            primary = loc["grave_location"]
+        elif loc.get("parcel"):
+            primary = loc["parcel"]
+        else:
+            primary = loc.get("location") or ""
+
+        parts = list(filter(None, [primary, postcode_city, province]))
+        return ", ".join(parts)
+
+    # ── private format helpers ───────────────────────────────────────
+
+    def _format_date(self, entity: dict) -> tuple[dict, list[dict]]:
+        """Returns (first_entry, all_objects)."""
+        parse_results = self._date_parser.parse(entity["text"])
+        base = entity.copy()
+        if not parse_results:
+            base.update({"formatted": None, "formatted_text": None, "result_object": None, "formatted_start": None, "formatted_end": None})
+            return base, []
+
+        r = parse_results[0]
+        start_date = r.start.isoformat()[:10]
+        end_date   = r.end.isoformat()[:10]
+
+        objects = []
+        for shape in self._DATE_OBJECT_MAP.get(entity.get("label", ""), []):
+            if shape == "interval":
+                objects.append(self._make_interval_obj(start_date, end_date))
+            else:
+                objects.append({"type": "xsd:Date", "value": start_date})
+
+        first_obj = objects[0]
+        base["formatted"] = {
+            "type": "date",
+            **self._date_parse_dict(r),
+            "objects": [first_obj],
+        }
+        if len(parse_results) > 1:
+            base["formatted"]["additional"] = [self._date_parse_dict(dr) for dr in parse_results[1:]]
+        base["formatted_text"]  = self._object_formatted_text(first_obj)
+        base["result_object"]   = self._object_result_object(first_obj)
+        base["formatted_start"] = f'"{start_date}"^^xsd:Date'
+        base["formatted_end"]   = f'"{end_date}"^^xsd:Date'
+        return base, objects
+
+    def _format_location(self, entity: dict) -> tuple[dict, list[dict]]:
+        """Returns (first_entry, all_locations)."""
+        result = self._location_formatter.parse(entity["text"])
+        base = entity.copy()
+        if not result or not result.get("locations"):
+            base.update({"formatted": None, "formatted_text": None, "result_object": None, "formatted_start": None, "formatted_end": None})
+            return base, []
+
+        locations = result["locations"]
+        base["formatted"]       = {"type": "location", "locations": [locations[0]]}
+        base["formatted_text"]  = self._address_text(locations[0])
+        base["result_object"]   = None
+        base["formatted_start"] = None
+        base["formatted_end"]   = None
+        return base, locations
+
+    # ── expansion ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _expand(first: dict, all_items: list, entry_fn) -> list[dict]:
+        """Expand into one entry per item.  If ≤1 item, return first as-is."""
+        if len(all_items) <= 1:
+            return [first]
+        base = {k: v for k, v in first.items()
+                if k not in ("formatted", "formatted_text", "result_object")}
+        base_fmt = {k: v for k, v in first.get("formatted", {}).items()
+                    if k not in ("objects", "locations")}
+        return [entry_fn(base, base_fmt, item) for item in all_items]
+
+    @staticmethod
+    def _date_entry(base: dict, base_fmt: dict, obj: dict) -> dict:
+        return {
+            **base,
+            "formatted_text": EntityFormatter._object_formatted_text(obj),
+            "result_object":  EntityFormatter._object_result_object(obj),
+            "formatted":      {**base_fmt, "objects": [obj]},
+        }
+
+    @staticmethod
+    def _location_entry(base: dict, base_fmt: dict, loc: dict) -> dict:
+        return {
+            **base,
+            "formatted_text": EntityFormatter._address_text(loc),
+            "result_object":  None,
+            "formatted":      {**base_fmt, "locations": [loc]},
+        }

--- a/src/task/entity_extraction.py
+++ b/src/task/entity_extraction.py
@@ -60,8 +60,6 @@ class EntityExtractionTask(DecisionTask):
         Returns:
             list[str]: List of URIs of the created annotation resources for applicable entities.
         """
-        print(f"[GENERAL ENTITIES] subject: {self.source}; source_uri: {source_uri}")
-
         created_annotation_uris: list[str] = []
 
         # Resolve the work URI for this expression once (may be None if unknown)
@@ -318,7 +316,6 @@ class EntityExtractionTask(DecisionTask):
             
             # Clean up entities by formatting the dates, periods and splitting the locations into individual entities.
             general_entities_formatted = entity_formatter.format(general_entities)
-            print(f"[FORMATTED ENTITIES] {general_entities_formatted}")
 
             entity_uris = self.create_general_entity_annotations(
                 target_expression_uri, general_entities_formatted)

--- a/src/task/entity_extraction.py
+++ b/src/task/entity_extraction.py
@@ -13,7 +13,10 @@ from ..ner_functions import extract_entities
 from ..config import get_config
 from ..entity_mappers import map_entity_to_annotations, resolve_work_uri_for_expression
 from ..library.entity_projections import project_spans
+from ..library.entity_formatter import EntityFormatter
 
+# Instantiate a single EntityFormatter to reuse across tasks.
+entity_formatter = EntityFormatter()
 
 class EntityExtractionTask(DecisionTask):
     """Task that extracts named entities from text."""
@@ -312,8 +315,13 @@ class EntityExtractionTask(DecisionTask):
             # Extract general entities (DATE, etc.) on the English text
             general_entities = self.extract_general_entities(
                 target_english_text, language="en")
+            
+            # Clean up entities by formatting the dates, periods and splitting the locations into individual entities.
+            general_entities_formatted = entity_formatter.format(general_entities)
+            print(f"[FORMATTED ENTITIES] {general_entities_formatted}")
+
             entity_uris = self.create_general_entity_annotations(
-                target_expression_uri, general_entities)
+                target_expression_uri, general_entities_formatted)
 
             for entity_uri in entity_uris:
                 self.results_container_uris.append(
@@ -328,7 +336,12 @@ class EntityExtractionTask(DecisionTask):
                 continue
 
             general_entities_projected = project_spans(target_english_text,source_text,general_entities)
-            entity_uris_projected = self.create_general_entity_annotations(source_expression_uri, general_entities_projected)
+
+            # Format the projected entities as well to ensure the same level of detail in the annotations (e.g. date parsing, location splitting).
+            general_entities_projected_formatted = entity_formatter.format(general_entities_projected)
+            entity_uris_projected = self.create_general_entity_annotations(source_expression_uri, general_entities_projected_formatted)
+
+
             for projected_entity_uri in entity_uris_projected:
                 self.results_container_uris.append(
                     self.create_output_container(projected_entity_uri))


### PR DESCRIPTION
What has been done

**NER task**

- Added a new EntityFormatter class that uses DatePeriodParser and LocationFormatter.
- Added post-processing to split location entities that refer to multiple addresses into separate entities.


**Mapping to annotations**

- Added parsing of date strings (e.g. "7 januari 2026", "7 april tot 10 april") into sequences of datetime objects.
- Updated the date and period handling in map_entity_to_annotations to align with the datetime representation described in the [AI annotations data model](https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/grRYjcouX0uZY2P6PYBl/data-analysis-research/datamodel-ai-annotations).
- Updated location annotation mapping to use the labels of the individual locations.