### PR TITLE
Feat/segmentation through langchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,17 @@ Used by `entity-extracting` (title extraction) and `model-annotating` (SDG class
 ---
 
 ### `segmentation`
-Used by the `segmenting` task.
+Used by the `segmenting` task. Settings are split between top-level keys and the nested `llm` block.
 
 | Key | Default | Effect |
 |---|---|---|
-| `model_name` | `gpt-4.1` | Set to `wdmuer/decide-marked-segmentation` to use the local specialized model instead of a generic LLM |
-| `api_key` / `endpoint` | `null` | Required for external LLM endpoints |
-| `max_new_tokens` | `14000` | Generation budget; reduce for faster but potentially truncated output |
-| `temperature` | `0.1` | Lower = more deterministic segmentation |
+| `max_new_tokens` | `14000` | Generation budget for GemmaSegmentor; not used by LLMSegmentor |
+| `max_gap` | `5` | Maximum character gap allowed when projecting segments back to the source expression |
+| `llm.provider` | `ollama` | LangChain provider name (`ollama`, `openai`, `mistral`, `azure_openai`, …) |
+| `llm.model_name` | `mistral-nemo` | Model name. Set to `wdmuer/decide-marked-segmentation` to use the local GemmaSegmentor instead |
+| `llm.api_key` | `null` | API key — required for external providers (OpenAI, Mistral, …) |
+| `llm.base_url` | `null` | Custom endpoint URL — required for Ollama and self-hosted models |
+| `llm.temperature` | `0.0` | Lower = more deterministic segmentation |
 
 ---
 
@@ -172,27 +175,46 @@ Nominatim is included in docker-compose. First startup can take longer than usua
 The service supports two different segmentation models, configurable via `config.json`.
 
 ### 1. LLMSegmentor (Generic LLM)
-Default usage for general LLMs (OpenAI, Azure OpenAI, Mistral, Ollama, etc.). It instructs the model to return JSON structure.
+Default. Works with any LangChain-supported provider (OpenAI, Ollama, Mistral, Azure OpenAI, …). Instructs the model to return tagged JSON.
 
-**Configuration in `config.json`:**
+**Example — Ollama (`config.json`):**
 ```json
 "segmentation": {
-  "model_name": "gpt-4.1",       // Your model deployment name
-  "api_key": "YOUR_KEY",
-  "endpoint": "YOUR_ENDPOINT",
-  "temperature": 0.1,
-  "max_new_tokens": 14000
+  "llm": {
+    "provider": "ollama",
+    "model_name": "mistral-nemo",
+    "base_url": "http://ollama:11434",
+    "temperature": 0.0
+  },
+  "max_new_tokens": 20000,
+  "max_gap": 5
+}
+```
+
+**Example — OpenAI:**
+```json
+"segmentation": {
+  "llm": {
+    "provider": "openai",
+    "model_name": "gpt-4.1",
+    "api_key": "YOUR_KEY",
+    "temperature": 0.0
+  },
+  "max_new_tokens": 20000,
+  "max_gap": 5
 }
 ```
 
 ### 2. GemmaSegmentor (Specialized Model)
-Uses the specialized `wdmuer/decide-marked-segmentation` model which is trained to output XML tags directly. Use this if you want to reproduce the original/legacy behavior.
+Uses the specialized `wdmuer/decide-marked-segmentation` model which outputs XML tags directly. Legacy behaviour.
 
-**To enable this mode**, you must set the `model_name` specifically:
+**To enable**, set `llm.model_name` to the exact model ID:
 ```json
 "segmentation": {
-  "model_name": "wdmuer/decide-marked-segmentation",
-  "max_new_tokens": 4000
-  // ... other fields as needed
+  "llm": {
+    "model_name": "wdmuer/decide-marked-segmentation"
+  },
+  "max_new_tokens": 4000,
+  "max_gap": 5
 }
 ```

--- a/config.json
+++ b/config.json
@@ -33,11 +33,14 @@
     }
   },
   "segmentation": {
-    "model_name": "gpt-4.1",
-    "api_key": "<YOUR_API_KEY>",
-    "endpoint": "<YOUR_ENDPOINT>",
+    "llm": {
+      "provider": "ollama",
+      "model_name": "mistral-nemo",
+      "api_key": null,
+      "base_url": "http://ollama:11434",
+      "temperature": 0.1
+    },
     "max_new_tokens": 20000,
-    "temperature": 0.1,
     "max_gap": 5
   }
 }

--- a/src/config.py
+++ b/src/config.py
@@ -163,25 +163,24 @@ class TranslationConfig(BaseModel):
         return v.strip().lower() if isinstance(v, str) else v
 
 
-class SegmentationConfig(BaseModel):
-    """Segmentation model configuration for document structure extraction."""
-    
+class LlmConfig(BaseModel):
+    """LLM provider configuration for the segmentation task."""
+
+    provider: str = Field(
+        default="ollama",
+        description="LangChain provider name, e.g. 'ollama', 'openai', 'mistral', 'azure_openai'"
+    )
     model_name: str = Field(
-        default="gpt-4.1",
-        description="LLM deployment / model name"
+        default="mistral-nemo",
+        description="Model name as understood by the provider"
     )
     api_key: SecretStr | None = Field(
         default=None,
-        description="API key for the LLM endpoint"
+        description="API key for the provider"
     )
-    endpoint: str | None = Field(
+    base_url: str | None = Field(
         default=None,
-        description="API endpoint URL for the LLM service"
-    )
-    max_new_tokens: int = Field(
-        default=14000,
-        ge=100,
-        description="Maximum tokens to generate"
+        description="Custom base URL (required for Ollama and self-hosted endpoints)"
     )
     temperature: float = Field(
         default=0.0,
@@ -190,6 +189,19 @@ class SegmentationConfig(BaseModel):
         description="Generation temperature (lower = more deterministic)"
     )
 
+
+class SegmentationConfig(BaseModel):
+    """Segmentation model configuration for document structure extraction."""
+
+    llm: LlmConfig = Field(
+        default_factory=LlmConfig,
+        description="LLM provider and model settings"
+    )
+    max_new_tokens: int = Field(
+        default=14000,
+        ge=100,
+        description="Maximum tokens to generate"
+    )
     max_gap: int = Field(
         default=5,
         description="Maximum character gap allowed when projecting segments back to original text. "

--- a/src/library/LLMAnalyzer.py
+++ b/src/library/LLMAnalyzer.py
@@ -1,292 +1,142 @@
 import json
-from typing import Dict, List, Any, Optional, Union
-import asyncio
-from tqdm import tqdm
-import os
+import re
+from typing import Dict, Any, Optional
 
-# 1. Update Imports
-from openai import AsyncAzureOpenAI, AsyncOpenAI 
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import SystemMessage, HumanMessage
 
 
 class LLMAnalyzer:
     """
-    A flexible analyzer class for processing text with Azure OpenAI OR Local LLMs (Ollama).
+    Analyzer that routes LLM calls through LangChain's init_chat_model factory.
+    Supports any provider recognised by LangChain (openai, ollama, mistral,
+    azure_openai, …) purely through configuration — no if/else branching.
     """
-    
-    def __init__(self, 
-                 api_key: Optional[str] = None, 
-                 endpoint: Optional[str] = None, 
-                 deployment: str = "gpt-4.1-nano",
-                 api_version: str = "2024-10-21"):
-        """
-        Initialize the analyzer. Auto-detects provider based on endpoint URL.
-        """
-        self.deployment = deployment
-        self.api_version = api_version
-        
-        # 2. Flexible Configuration
-        # If no key provided for local, use dummy "ollama"
-        self.api_key = api_key or os.getenv("AZURE_OPENAI_KEY") or "ollama"
-        self.endpoint = endpoint or os.getenv("AZURE_OPENAI_ENDPOINT") or "http://localhost:11434/v1"
-        
-        # 3. Client Selection Logic
-        if "azure.com" in self.endpoint:
-            print(f"Connecting to Azure OpenAI: {self.deployment}")
-            self.client = AsyncAzureOpenAI(
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.endpoint
-            )
-        else:
-            print(f"Connecting to Local/OpenAI/Minstral via Openai API: {self.deployment}")
-            self.client = AsyncOpenAI(
-                api_key=self.api_key,
-                base_url=self.endpoint
-            )
-    
-    async def analyze_single_entry(self, 
-                                 text: str, 
-                                 system_prompt: str, 
-                                 user_prompt_template: str,
-                                 expected_schema: Dict[str, Any],
-                                 max_tokens: int = 8000,
-                                 temperature: float = 0.1,
-                                 text_limit: int = 8000) -> Dict[str, Any]:
-        
+
+    def __init__(
+        self,
+        provider: str = "ollama",
+        model_name: str = "mistral-nemo",
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        temperature: float = 0.0,
+    ):
+        self.model_name = model_name
+        self._provider = provider
+
+        kwargs: Dict[str, Any] = {"temperature": temperature}
+        if api_key:
+            kwargs["api_key"] = api_key
+        if base_url:
+            kwargs["base_url"] = base_url
+
+        self._chat_model = init_chat_model(
+            f"{provider}:{model_name}",
+            **kwargs,
+        )
+
+    async def analyze_single_entry(
+        self,
+        text: str,
+        system_prompt: str,
+        user_prompt_template: str,
+        expected_schema: Dict[str, Any],
+        text_limit: int = 8000,
+    ) -> Dict[str, Any]:
+
         user_prompt = user_prompt_template.format(text=text[:text_limit])
-        
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=user_prompt),
+        ]
+
         try:
-            # 4. Minimal logic tweak for compatibility
-            # O1/GPT-5 models often use 'max_completion_tokens', others use 'max_tokens'
-            is_reasoning_model = self.deployment.startswith(("gpt-5", "o1"))
-            
-            completion_args = {
-                "model": self.deployment,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt}
-                ],
-                "response_format": {"type": "json_object"} # Ollama supports this in v1 API
-            }
-
-            if is_reasoning_model:
-                completion_args["max_completion_tokens"] = max_tokens
-            else:
-                completion_args["max_tokens"] = max_tokens
-                completion_args["temperature"] = temperature
-
-            response = await self.client.chat.completions.create(**completion_args)
-
-            # ... [Rest of your existing parsing logic remains exactly the same] ...
-            result_text = response.choices[0].message.content
-            result_text = result_text.strip()
-            result = json.loads(result_text)
+            response = await self._chat_model.ainvoke(messages)
+            result = self._parse_json(response.content)
             return self._validate_result(result, expected_schema)
-            
+
         except Exception as e:
             print(f"Analysis error: {e}")
             return self._create_error_result(expected_schema, f"Analysis failed: {str(e)}")
 
+    # JSON parsing — three fallback strategies
+    def _parse_json(self, text: str) -> Dict[str, Any]:
+        """Parse JSON from LLM response with three fallback strategies."""
+        text = text.strip()
+
+        # 1. Direct parse
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+
+        # 2. Strip markdown code fences
+        fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text)
+        if fence_match:
+            try:
+                return json.loads(fence_match.group(1))
+            except json.JSONDecodeError:
+                pass
+
+        # 3. Regex: find first {...} block
+        brace_match = re.search(r"\{[\s\S]*\}", text)
+        if brace_match:
+            try:
+                return json.loads(brace_match.group(0))
+            except json.JSONDecodeError:
+                pass
+
+        raise ValueError(f"Could not parse JSON from response: {text[:200]}")
+
+    # Schema validation helpers
     def _validate_result(self, result: Dict[str, Any], expected_schema: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Validate and structure the result according to the expected schema.
-        
-        Args:
-            result: Raw result from AI
-            expected_schema: Expected structure with default values and types
-        
-        Returns:
-            dict: Validated result matching schema
-        """
         validated_result = {}
-        
-        
+
         for key, schema_info in expected_schema.items():
-            
             if isinstance(schema_info, dict) and "default" in schema_info:
                 default_value = schema_info["default"]
                 expected_type = schema_info.get("type", type(default_value))
-                
-                # Clean the key and look for it in result
+
                 clean_key = key.strip()
                 value = None
-                
-                # Try to find the key (handle potential whitespace issues)
+
                 for result_key in result.keys():
                     if result_key.strip() == clean_key:
                         value = result[result_key]
                         break
-                
+
                 if value is not None:
-                    # Handle list type validation
                     if expected_type == list:
                         if isinstance(value, list):
                             validated_result[clean_key] = value
-                        elif value:  # Convert non-empty single values to list
+                        elif value:
                             validated_result[clean_key] = [value]
                         else:
                             validated_result[clean_key] = default_value
                     else:
-                        # Handle other types
                         validated_result[clean_key] = value if isinstance(value, expected_type) else default_value
                 else:
                     validated_result[clean_key] = default_value
             else:
-                # Simple default value
                 clean_key = key.strip()
-                # Try to find the key in result
                 value = None
                 for result_key in result.keys():
                     if result_key.strip() == clean_key:
                         value = result[result_key]
                         break
                 validated_result[clean_key] = value if value is not None else schema_info
-        
+
         return validated_result
-    
+
     def _create_error_result(self, expected_schema: Dict[str, Any], error_message: str) -> Dict[str, Any]:
-        """
-        Create an error result that matches the expected schema.
-        
-        Args:
-            expected_schema: Expected structure
-            error_message: Error message to include
-        
-        Returns:
-            dict: Error result with schema structure
-        """
         error_result = {}
-        
+
         for key, schema_info in expected_schema.items():
             clean_key = key.strip()
             if isinstance(schema_info, dict) and "default" in schema_info:
                 error_result[clean_key] = schema_info["default"]
             else:
                 error_result[clean_key] = schema_info
-        
+
         error_result["error"] = error_message
         return error_result
-    
-    async def analyze_batch(self, 
-                          entries: List[Dict], 
-                          text_field: str,
-                          system_prompt: str,
-                          user_prompt_template: str,
-                          expected_schema: Dict[str, Any],
-                          analysis_field: str = "analysis_result",
-                          batch_size: int = 5, 
-                          max_entries: Optional[int] = None, 
-                          start_index: int = 0, 
-                          output_file: Optional[str] = None,
-                          **analysis_kwargs) -> List[Dict]:
-        """
-        Analyze multiple entries in batches with progress tracking and optional file output.
-        
-        Args:
-            entries: List of entries to analyze
-            text_field: Field name containing text to analyze
-            system_prompt: System prompt for the AI
-            user_prompt_template: User prompt template (should contain {text} placeholder)
-            expected_schema: Dictionary defining the expected output structure
-            analysis_field: Field name to store analysis results
-            batch_size: Number of concurrent requests
-            max_entries: Maximum number of entries to process
-            start_index: Number of entries to skip from the beginning
-            output_file: Optional path to save results progressively
-            **analysis_kwargs: Additional arguments for analyze_single_entry
-        
-        Returns:
-            list: Entries extended with analysis results
-        """
-        
-        # Apply start_index and max_entries filtering
-        if start_index > 0:
-            entries = entries[start_index:]
-        entries_to_process = entries[:max_entries] if max_entries else entries
-        
-        print(f"Analyzing {len(entries_to_process)} entries (batch size: {batch_size})")
-        print(f"Processing from index {start_index} to {start_index + len(entries_to_process) - 1}")
-        if output_file:
-            print(f"Saving to: {output_file}")
-        
-        analyzed_entries = []
-        successful_count = 0
-        error_count = 0
-        
-        # Ensure output directory exists if output_file is specified
-        if output_file:
-            from pathlib import Path
-            Path(output_file).parent.mkdir(parents=True, exist_ok=True)
-        
-        # Open output file for writing if specified
-        outfile = None
-        if output_file:
-            outfile = open(output_file, 'a', encoding='utf-8')
-        
-        try:
-            # Process entries in batches with progress bar
-            with tqdm(total=len(entries_to_process), desc="Analyzing entries", unit="entry") as pbar:
-                for i in range(0, len(entries_to_process), batch_size):
-                    batch = entries_to_process[i:i + batch_size]
-                    
-                    # Create tasks for concurrent processing
-                    tasks = []
-                    for entry in batch:
-                        text = entry.get(text_field, "")
-                        task = self.analyze_single_entry(
-                            text=text,
-                            system_prompt=system_prompt,
-                            user_prompt_template=user_prompt_template,
-                            expected_schema=expected_schema,
-                            **analysis_kwargs
-                        )
-                        tasks.append(task)
-                    
-                    # Execute batch concurrently
-                    try:
-                        batch_results = await asyncio.gather(*tasks, return_exceptions=True)
-                        
-                        # Process results and save immediately if output file specified
-                        for entry, result in zip(batch, batch_results):
-                            if isinstance(result, Exception):
-                                entry[analysis_field] = self._create_error_result(
-                                    expected_schema, str(result)
-                                )
-                                error_count += 1
-                            else:
-                                entry[analysis_field] = result
-                                successful_count += 1
-                            
-                            # Save entry immediately to file if specified
-                            if outfile:
-                                outfile.write(json.dumps(entry, ensure_ascii=False) + '\n')
-                                outfile.flush()  # Ensure data is written
-                            
-                            analyzed_entries.append(entry)
-                            pbar.update(1)
-                    
-                    except Exception as e:
-                        # Handle batch errors
-                        for entry in batch:
-                            entry[analysis_field] = self._create_error_result(
-                                expected_schema, f"Batch error: {str(e)}"
-                            )
-                            if outfile:
-                                outfile.write(json.dumps(entry, ensure_ascii=False) + '\n')
-                                outfile.flush()
-                            analyzed_entries.append(entry)
-                            error_count += 1
-                            pbar.update(1)
-                    
-                    # Rate limiting delay
-                    if i + batch_size < len(entries_to_process):
-                        await asyncio.sleep(1)
-        
-        finally:
-            if outfile:
-                outfile.close()
-        
-        # Final summary
-        print(f"Complete: {successful_count} success, {error_count} errors")
-        
-        return analyzed_entries

--- a/src/library/segmentors.py
+++ b/src/library/segmentors.py
@@ -25,10 +25,10 @@ except ImportError:
 class AbstractSegmentor(ABC):
     """Abstract base class for a segmentation strategy."""
     
-    def __init__(self, api_key: str = None, endpoint: str = None, model_name: str = None, temperature: float = 0.1, max_new_tokens: int = 2000):
+    def __init__(self, api_key: str = None, base_url: str = None, model_name: str = None, temperature: float = 0.1, max_new_tokens: int = 2000):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.api_key = api_key
-        self.endpoint = endpoint
+        self.base_url = base_url
         self.model_name = model_name
         self.temperature = temperature
         self.max_new_tokens = max_new_tokens
@@ -69,8 +69,8 @@ SEGMENTS:
 ```
 ['TITLE', 'PARTICIPANTS', 'MOTIVATION', 'PREVIOUS_DECISIONS', 'LEGAL_FRAMEWORK', 'DECISION', 'VOTING', 'ARTICLE']
 ```"""
-    def __init__(self, api_key: str = None, endpoint: str = None, model_name: str = "wdmuer/decide-marked-segmentation", temperature: float = 0.1, max_new_tokens: int = 4096):
-        super().__init__(api_key, endpoint, model_name, temperature, max_new_tokens)
+    def __init__(self, api_key: str = None, base_url: str = None, model_name: str = "wdmuer/decide-marked-segmentation", temperature: float = 0.1, max_new_tokens: int = 4096):
+        super().__init__(api_key, base_url, model_name, temperature, max_new_tokens)
    
 
     def get_generator(self):
@@ -440,15 +440,17 @@ class LLMSegmentor(AbstractSegmentor):
         "document_classification": {"default": "", "type": str}
         }
 
-    def __init__(self, api_key: str = None, endpoint: str = None, model_name: str = "gpt-4.1", temperature: float = 0.0, max_new_tokens: int = 14000):
-        super().__init__(api_key, endpoint, model_name, temperature, max_new_tokens)
+    def __init__(self, api_key: str = None, base_url: str = None, model_name: str = "mistral-nemo", temperature: float = 0.0, max_new_tokens: int = 14000, provider: str = "ollama"):
+        super().__init__(api_key, base_url, model_name, temperature, max_new_tokens)
         if LLMAnalyzer is None:
              raise ImportError("LLMAnalyzer class is not available.")
-        
+
         self.analyzer = LLMAnalyzer(
-            api_key=self.api_key, 
-            endpoint=self.endpoint, 
-            deployment=self.model_name
+            provider=provider,
+            model_name=self.model_name,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            temperature=self.temperature,
         )
 
     def format_segment(self, segment: Dict[str, Any]) -> Dict[str, Any]:
@@ -461,7 +463,7 @@ class LLMSegmentor(AbstractSegmentor):
         }
 
     async def async_segment(self, text: str) -> List[Dict[str, Any]]:
-        self.logger.info(f"Running LLM segmentation with {self.analyzer.deployment}...")
+        self.logger.info(f"Running LLM segmentation with {self.analyzer.model_name}...")
         
         try:
              result = await self.analyzer.analyze_single_entry(
@@ -469,9 +471,7 @@ class LLMSegmentor(AbstractSegmentor):
                 system_prompt=self.SYSTEM_PROMPT_REFERENCES_SEGMENTATION,
                 user_prompt_template=self.USER_PROMPT_TEMPLATE_REFERENCES_SEGMENTATION,
                 expected_schema=self.RESULTS_SCHEMA_SEGMENTATION,
-                max_tokens=self.max_new_tokens,
-                temperature=self.temperature,
-                text_limit=28000
+                text_limit=28000,
             )
         except Exception as e:
             self.logger.error(f"LLM segmentation failed: {e}")

--- a/src/task/segmentation.py
+++ b/src/task/segmentation.py
@@ -122,22 +122,23 @@ class SegmentationTask(DecisionTask):
         """Create a Segmentor configured from app config."""
         from ..library.segmentors import GemmaSegmentor, LLMSegmentor
         seg_config = get_config().segmentation
-        api_key = seg_config.api_key.get_secret_value() if seg_config.api_key else None
+        api_key = seg_config.llm.api_key.get_secret_value() if seg_config.llm.api_key else None
 
-        if seg_config.model_name == "wdmuer/decide-marked-segmentation":
+        if seg_config.llm.model_name == "wdmuer/decide-marked-segmentation":
             return GemmaSegmentor(
                 api_key=api_key,
-                endpoint=seg_config.endpoint,
-                model_name=seg_config.model_name,
-                temperature=seg_config.temperature,
+                base_url=seg_config.llm.base_url,
+                model_name=seg_config.llm.model_name,
+                temperature=seg_config.llm.temperature,
                 max_new_tokens=seg_config.max_new_tokens,
             )
         else:
             return LLMSegmentor(
+                provider=seg_config.llm.provider,
+                model_name=seg_config.llm.model_name,
                 api_key=api_key,
-                endpoint=seg_config.endpoint,
-                model_name=seg_config.model_name,
-                temperature=seg_config.temperature,
+                base_url=seg_config.llm.base_url,
+                temperature=seg_config.llm.temperature,
                 max_new_tokens=seg_config.max_new_tokens,
             )
 


### PR DESCRIPTION
This PR introduces a 'langchain' approach for segmentation. making it possible to use a wide variety of LLMs for segmentation.

to test this, update the segmentationprovider to 'langchain' and update the langchain config accordingly with your endpoint and/or api-key. Currently the default values will use mistral-nemo through ollama for segmentation.