### PR TITLE
Bump ai_service_base to 0.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ pydantic>=2.0.0
 SPARQLWrapper
 translatepy
 span-aligner>=0.2.4
-https://github.com/semantic-ai/decide-ai-service-base/releases/download/0.1.3/decide_ai_service_base-0.1.3-py3-none-any.whl
+https://github.com/semantic-ai/decide-ai-service-base/releases/download/0.1.4/decide_ai_service_base-0.1.4-py3-none-any.whl


### PR DESCRIPTION
-bump to 0.1.4 of base_service for new agent URIs (stil requires the release of this new version)