### PR TITLE
Fix/locks

### DIFF
--- a/src/library/entity_projections.py
+++ b/src/library/entity_projections.py
@@ -1,15 +1,6 @@
 from typing import List, Dict, Union, Any
 from span_aligner import SpanProjector
 
-# Singleton instance
-_projector = None
-
-def _get_projector() -> SpanProjector:
-    """Lazy load the SpanProjector singleton."""
-    global _projector
-    if _projector is None:
-        _projector = SpanProjector()
-    return _projector
 
 def project_spans(
     src_text: str, 
@@ -41,7 +32,8 @@ def project_spans(
         })
 
     # Use the projector to project spans from source to target text
-    projected_spans = _get_projector().project_spans(src_text, tgt_text, formatted_spans, max_gap=max_gap)
+    projector = SpanProjector()
+    projected_spans = projector.project_spans(src_text, tgt_text, formatted_spans, max_gap=max_gap)
 
     formatted_projected_spans = []
     for span in projected_spans:

--- a/web.py
+++ b/web.py
@@ -22,7 +22,7 @@ async def startup_event():
     wait_for_triplestore()
     fail_busy_and_scheduled_tasks()
     register_airo()
-    process_open_tasks()
+    process_open_tasks(_open_tasks_lock)
 
 
 


### PR DESCRIPTION
Provide lock processing open tasks on startup and initialize the SpanProjector insinde project_spans to avoid "Already borrowed" error