### PR TITLE
feat: Add retry mechanism for LLM calls with configurable retries and delay

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -135,6 +135,16 @@ class LangChainTranslationConfig(BaseModel):
         ge=200,
         description="Maximum characters per translation chunk"
     )
+    max_retries: int = Field(
+        default=3,
+        ge=1,
+        description="Max attempts on LLM call failure"
+    )
+    retry_delay: float = Field(
+        default=15.0,
+        ge=0,
+        description="Seconds to sleep between retries"
+    )
 
 
 class TranslationConfig(BaseModel):
@@ -188,6 +198,16 @@ class LlmConfig(BaseModel):
         ge=0.0,
         le=2.0,
         description="Generation temperature (lower = more deterministic)"
+    )
+    max_retries: int = Field(
+        default=3,
+        ge=1,
+        description="Max attempts on LLM call failure"
+    )
+    retry_delay: float = Field(
+        default=15.0,
+        ge=0,
+        description="Seconds to sleep between retries"
     )
 
 

--- a/src/library/LLMAnalyzer.py
+++ b/src/library/LLMAnalyzer.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import SystemMessage, HumanMessage
+from ..retry import retry_call
 import json_repair
 
 
@@ -23,9 +24,13 @@ class LLMAnalyzer:
         base_url: Optional[str] = None,
         temperature: float = 0.0,
         json_mode: bool = True,
+        max_retries: int = 3,
+        retry_delay: float = 15.0,
     ):
         self.model_name = model_name
         self._provider = provider
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
 
         kwargs: Dict[str, Any] = {"temperature": temperature}
         if api_key:
@@ -42,7 +47,7 @@ class LLMAnalyzer:
             f"{provider}:{model_name}",
             **kwargs,
             timeout=600,
-            max_retries=3
+            max_retries=0,
         )
 
     def analyze_single_entry_simple(
@@ -67,7 +72,7 @@ class LLMAnalyzer:
             HumanMessage(content=user_prompt),
         ]
 
-        response = llm.invoke(messages)
+        response = retry_call(llm.invoke, messages,max_retries=self._max_retries, retry_delay=self._retry_delay)
 
         if response["parsing_error"]:
             raise ValueError(
@@ -94,7 +99,7 @@ class LLMAnalyzer:
         ]
 
         try:
-            response = self._chat_model.invoke(messages)
+            response = retry_call(self._chat_model.invoke, messages,max_retries=self._max_retries, retry_delay=self._retry_delay)
             result = self._parse_json(response.content)
             return self._validate_result(result, expected_schema)
 

--- a/src/library/segmentors.py
+++ b/src/library/segmentors.py
@@ -446,7 +446,7 @@ class LLMSegmentor(AbstractSegmentor):
         }
 
 
-    def __init__(self, api_key: str = None, base_url: str = None, model_name: str = "mistral-nemo", temperature: float = 0.0, max_new_tokens: int = 14000, provider: str = "ollama"):
+    def __init__(self, api_key: str = None, base_url: str = None, model_name: str = "mistral-nemo", temperature: float = 0.0, max_new_tokens: int = 14000, provider: str = "ollama", max_retries: int = 3, retry_delay: float = 15.0):
         super().__init__(api_key, base_url, model_name, temperature, max_new_tokens)
         if LLMAnalyzer is None:
              raise ImportError("LLMAnalyzer class is not available.")
@@ -457,6 +457,8 @@ class LLMSegmentor(AbstractSegmentor):
             api_key=self.api_key,
             base_url=self.base_url,
             temperature=self.temperature,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
         )
 
     def format_segment(self, segment: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/retry.py
+++ b/src/retry.py
@@ -1,0 +1,28 @@
+"""Minimal retry helper for outbound LLM calls: retry on any failure with a fixed sleep."""
+import asyncio
+import time
+from helpers import logger
+
+
+def retry_call(fn, *args, max_retries=3, retry_delay=15.0, **kwargs):
+    for attempt in range(1, max_retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_retries:
+                raise
+            logger.warning("LLM call failed (attempt %d/%d), retrying in %.0fs: %s",
+                           attempt, max_retries, retry_delay, exc)
+            time.sleep(retry_delay)
+
+
+async def aretry_call(fn, *args, max_retries=3, retry_delay=15.0, **kwargs):
+    for attempt in range(1, max_retries + 1):
+        try:
+            return await fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_retries:
+                raise
+            logger.warning("LLM call failed (attempt %d/%d), retrying in %.0fs: %s",
+                           attempt, max_retries, retry_delay, exc)
+            await asyncio.sleep(retry_delay)

--- a/src/task/segmentation.py
+++ b/src/task/segmentation.py
@@ -140,6 +140,8 @@ class SegmentationTask(DecisionTask):
                 base_url=seg_config.llm.base_url,
                 temperature=seg_config.llm.temperature,
                 max_new_tokens=seg_config.max_new_tokens,
+                max_retries=seg_config.llm.max_retries,
+                retry_delay=seg_config.llm.retry_delay,
             )
 
     def create_segment_annotations(self, source_uri: str, segments: list[dict[str, Any]]) -> list[str]:

--- a/src/translation_plugin_langchain.py
+++ b/src/translation_plugin_langchain.py
@@ -18,6 +18,7 @@ from translatepy.models import TranslationResult
 from translatepy.translators.base import BaseTranslator
 
 from .config import get_config
+from .retry import retry_call
 
 
 LANGUAGE_NAMES: Dict[str, str] = {
@@ -66,6 +67,7 @@ class LangChainTranslateService(BaseTranslator):
         self._chat_model = init_chat_model(
             f"{self.config.provider}:{self.config.model_name}",
             **model_kwargs,
+            max_retries=0,
         )
 
         self.logger.info(
@@ -137,7 +139,7 @@ class LangChainTranslateService(BaseTranslator):
             SystemMessage(content=SYSTEM_PROMPT),
             HumanMessage(content=self._build_user_message(text, source_language, destination_language)),
         ]
-        response = self._chat_model.invoke(messages)
+        response = retry_call(self._chat_model.invoke, messages,max_retries=self.config.max_retries, retry_delay=self.config.retry_delay)
         translated = response.content.strip()
         if not translated:
             raise RuntimeError("LangChain translation returned an empty response")


### PR DESCRIPTION
introducing two functions to retry api/llm calls to retry when a call fails.
this is configurable by adding two variables to 1) control the number of retries and 2) control the delay between calls